### PR TITLE
Add EvoTokenDLM and DiSE (ACL 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ A comprehensive and structured list of research papers about **Large-Language-Di
 | [Beyond Next-Token Prediction: A Performance Characterization of Diffusion versus Autoregressive Language Models](https://arxiv.org/abs/2510.04146v1) | 2025.10 | Arxiv | Speed Analysis |
 | [On the Role of Discreteness in Diffusion LLMs](https://arxiv.org/abs/2512.22630v1) | 2025.12 | Arxiv | Speed Analysis |
 | [ParallelBench: Understanding the Trade-offs of Parallel Decoding in Diffusion LLMs](https://arxiv.org/abs/2510.04767) | 2025.10 | ICLR |  |
+| [Efficient Self-Evaluation for Diffusion Language Models via Sequence Regeneration](https://arxiv.org/abs/2603.02760) | 2026.03 | ACL | Self-evaluation, Generalization analysis |
 
 ### 7.2 Guidance & Downstream Applications
 | Paper Title | Year | Venue | Remark |

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ A comprehensive and structured list of research papers about **Large-Language-Di
 | [Variational Masked Diffusion Models](https://arxiv.org/abs/2510.23606v1) | 2025.10 | Arxiv | <7B |
 | [TiDAR: Think in Diffusion, Talk in Autoregression](https://arxiv.org/abs/2511.08923v1) | 2025.11 | Arxiv | >7B |
 | [C2DLM: Causal Concept-Guided Diffusion Large Language Models](https://arxiv.org/abs/2511.22146v1) | 2025.11 | Arxiv | >7B |
+| [Beyond Hard Masks: Progressive Token Evolution for Diffusion Language Models](https://arxiv.org/abs/2601.07351) | 2026.01 | ACL | Soft tokens, Masked |
 
 ### 2.2 Continuous & Latent Space Diffusion
 | Paper Title | Year | Venue | Remark |
@@ -182,6 +183,7 @@ A comprehensive and structured list of research papers about **Large-Language-Di
 | [Parallel Sampling from Masked Diffusion Models via Conditional Independence Testing](https://arxiv.org/abs/2510.21961v1) | 2025.10 | Arxiv | >7B, Unmasking |
 | [Diffusion Language Model Inference with Monte Carlo Tree Search](https://arxiv.org/abs/2512.12168v1) | 2025.12 | Arxiv | >7B, Unmasking |
 | [Optimizing Decoding Paths in Masked Diffusion Models by Quantifying Uncertainty](https://arxiv.org/abs/2512.21336v1) | 2025.12 | Arxiv | >7B, Unmasking |
+| [Efficient Self-Evaluation for Diffusion Language Models via Sequence Regeneration](https://arxiv.org/abs/2603.02760) | 2026.03 | ACL | Self-evaluation, Flexible length |
 
 ---
 


### PR DESCRIPTION
Adds two ACL 2026 main-conference papers on diffusion language models:

- **EvoTokenDLM** (arXiv:2601.07351) — replaces hard binary masks with evolving soft-token distributions; introduces continuous trajectory supervision training. Code: https://github.com/aim-uofa/EvoTokenDLM → §2.1 Discrete & Masked Diffusion
- **DiSE** (arXiv:2603.02760) — training-free self-evaluation via token-regeneration probability; enables flexible-length generation. → §4 Token Ordering & Generation Strategies

Entries follow the existing table format. Chronological ordering preserved (appended to end of each section).

Disclosure: I am a co-author on both papers.