### PR TITLE
Add FOCUS paper (ICML 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ A comprehensive and structured list of research papers about **Large-Language-Di
 
 | Paper Title | Year | Venue | Remark |
 | :--- | :---: | :---: | :--- |
+| [FOCUS: DLLMs Know How to Tame Their Compute Bound](https://arxiv.org/abs/2601.23278) | 2026.01 | ICML | Training-free inference system; token eviction for higher throughput |
 | [dInfer: An Efficient Inference Framework for Diffusion Language Models](https://arxiv.org/abs/2510.08666v2) | 2025.10 | Arxiv | Modular framework, >1100 TPS |
 | [JetEngine (SDAR)](https://github.com/JetAstra/SDAR) | 2025.10 | Repo | Lightweight engine for SDAR (3700+ TPS on H200) |
 | [Mercury: Ultra-Fast Language Models Based on Diffusion](https://arxiv.org/abs/2506.17298v1) | 2025.06 | Arxiv | Inception Labs commercial dLLM |


### PR DESCRIPTION
This PR adds FOCUS, an ICML 2026 paper on training-free efficient inference system for diffusion LLMs, to the Inference Frameworks & Systems section.
The change follows the existing table format.

arXiv: https://arxiv.org/abs/2601.23278
GitHub: https://github.com/sands-lab/FOCUS

Disclosure: I am the first author of this paper.
